### PR TITLE
Use http not ssh for clone URLs, correct Cursor skill directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ Clone the repository into the skills directory of your AI agent.
 
 **Claude Code:**
 ```bash
-git clone git@github.com:juanje/context-generator.git ~/.claude/skills/context-generator
+git clone https://github.com/juanje/context-generator.git ~/.claude/skills/context-generator
 ```
 
 **Cursor:**
 ```bash
-git clone git@github.com:juanje/context-generator.git ~/.cursor/skills-cursor/context-generator
+git clone https://github.com/juanje/context-generator.git ~/.cursor/skills/context-generator
 ```
 
 Then restart your agent. The skill will be available automatically.


### PR DESCRIPTION
As per
https://gitlab.com/redhat/edge/ci-cd/ai-code-review/-/merge_requests/78 this uses http instead of ssh for cloning the repository in the instructions (there's no need to use ssh as we won't be pushing anything from this checkout, and it avoids problems if the user doesn't have ssh set up or has to do annoying authentications for an ssh clone), and corrects the clone location for Cursor (third party skills go to ~/.cursor/skills , ~/.cursor/skills-cursor is for first party skills).